### PR TITLE
fix: add py-cord in requirements file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,4 @@ token.txt
 conf/*
 .idea
 .env
-__pycache__/
-commands/__pycache__/
-events/__pycache__/
+__pycache__

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-dotenv==1.0.1
 PyYAML==6.0.1
+py-cord==2.6.1


### PR DESCRIPTION
Ajout de py-cord dans le requirements.txt afin de permettre de build l'image docker du bot